### PR TITLE
fix #44: 克隆完整的 GIT 历史

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
+          fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.PERSONAL_TOKEN }}
 


### PR DESCRIPTION
默认只拉取一条 GIT 历史，所以 Hugo 无法获得你的旧文件在 GIT 里的修改时间。

文档：https://github.com/actions/checkout#readme